### PR TITLE
Add always_ready_future archetype

### DIFF
--- a/archetypes/always_ready_future/Makefile
+++ b/archetypes/always_ready_future/Makefile
@@ -1,0 +1,2 @@
+saxpy: saxpy.cpp
+	clang -std=c++14 -O3 -lstdc++ saxpy.cpp -o saxpy

--- a/archetypes/always_ready_future/README.md
+++ b/archetypes/always_ready_future/README.md
@@ -1,0 +1,2 @@
+# always_ready_future
+An as-lightweight-as-possible `Future` type holding a value that is always ready as long as the future is valid.

--- a/archetypes/always_ready_future/always_ready_future.hpp
+++ b/archetypes/always_ready_future/always_ready_future.hpp
@@ -1,0 +1,270 @@
+// Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <exception>
+#include <type_traits>
+#include <utility>
+#include <future>
+#include "variant.hpp" // my compiler doesn't have <variant> yet
+#include "optional.hpp" // my compiler doesn't have <optional> yet
+
+// always_ready_future is intended to be a lightweight wrapper around
+// a ready value that fulfills the basic requirements of the Future concept
+// (whatever that may be someday)
+//
+// Executors which always block their client can use always_ready_future as their
+// associated future and still expose two-way asynchronous execution functions like .twoway_execute()
+
+template<class T>
+class always_ready_future
+{
+  public:
+    // Default constructor creates an invalid always_ready_future
+    // Postcondition: !valid()
+    always_ready_future() = default;
+
+    always_ready_future(const T& value) : state_(value) {}
+
+    always_ready_future(T&& value) : state_(std::move(value)) {}
+
+    always_ready_future(std::exception_ptr e) : state_(e) {}
+
+    always_ready_future(always_ready_future&& other)
+      : state_()
+    {
+      using std::swap;
+      swap(state_, other.state_);
+    }
+
+    always_ready_future& operator=(always_ready_future&& other)
+    {
+      state_.reset();
+
+      using std::swap;
+      swap(state_, other.state_);
+
+      return *this;
+    }
+
+    constexpr static bool is_ready()
+    {
+      return true;
+    }
+
+  private:
+    struct get_ptr_visitor
+    {
+      T* operator()(T& result) const
+      {
+        return &result;
+      }
+
+      T* operator()(std::exception_ptr& e) const
+      {
+        std::rethrow_exception(e);
+        return nullptr;
+      }
+    };
+
+    T& get_ref()
+    {
+      if(!valid())
+      {
+        throw std::future_error(std::future_errc::no_state);
+      }
+
+      return *std::experimental::visit(get_ptr_visitor(), *state_);
+    }
+
+  public:
+    T get()
+    {
+      T result = std::move(get_ref());
+
+      invalidate();
+
+      return result;
+    }
+
+    void wait() const
+    {
+      // wait() is a no-op: *this is always ready
+    }
+
+    bool valid() const
+    {
+      return state_.has_value();
+    }
+
+  private:
+    void invalidate()
+    {
+      state_ = std::experimental::nullopt;
+    }
+
+    std::experimental::optional<std::experimental::variant<T,std::exception_ptr>> state_;
+};
+
+
+template<>
+class always_ready_future<void>
+{
+  public:
+    // XXX the default constructor creates a ready, valid future, but we may wish
+    //     to redefine the default constructor to create an invalid future
+    //     in such a scheme, we would need to distinguish another constructor for
+    //     creating a ready (void) result.
+    //     We could create an emplacing constructor distinguished with an in_place_t parameter
+    always_ready_future() : valid_(true) {}
+
+    always_ready_future(std::exception_ptr e) : exception_(e), valid_(true) {}
+
+    always_ready_future(always_ready_future&& other)
+      : exception_(), valid_(false)
+    {
+      using std::swap;
+      swap(exception_, other.exception_);
+      swap(valid_, other.valid_);
+    }
+
+    always_ready_future& operator=(always_ready_future&& other)
+    {
+      exception_.reset();
+      valid_ = false;
+
+      using std::swap;
+      swap(exception_, other.exception_);
+      swap(valid_, other.valid_);
+      return *this;
+    }
+
+    constexpr static bool is_ready()
+    {
+      return true;
+    }
+
+  public:
+    void get()
+    {
+      if(!valid())
+      {
+        throw std::future_error(std::future_errc::no_state);
+      }
+
+      invalidate();
+
+      if(exception_)
+      {
+        std::rethrow_exception(exception_.value());
+      }
+    }
+
+    void wait() const
+    {
+      // wait() is a no-op: this is always ready
+    }
+
+    bool valid() const
+    {
+      return valid_;
+    }
+
+  private:
+    void invalidate()
+    {
+      valid_ = false;
+    }
+
+    std::experimental::optional<std::exception_ptr> exception_;
+
+    bool valid_;
+};
+
+
+template<class T>
+always_ready_future<std::decay_t<T>> make_always_ready_future(T&& value)
+{
+  return always_ready_future<std::decay_t<T>>(std::forward<T>(value));
+}
+
+inline always_ready_future<void> make_always_ready_future()
+{
+  return always_ready_future<void>();
+}
+
+
+template<class T>
+always_ready_future<T> make_always_ready_exceptional_future(std::exception_ptr e)
+{
+  return always_ready_future<T>(e);
+}
+
+
+namespace detail
+{
+
+
+template<class Function,
+         class Result = std::result_of_t<std::decay_t<Function>()>,
+         class = std::enable_if_t<
+           !std::is_void<Result>::value
+         >>
+always_ready_future<Result>
+try_invoke(Function&& f)
+{
+  try
+  {
+    return always_ready_future<Result>(std::forward<Function>(f)());
+  }
+  catch(...)
+  {
+    return always_ready_future<Result>(std::current_exception());
+  }
+}
+
+
+template<class Function,
+         class Result = std::result_of_t<std::decay_t<Function>()>,
+         class = std::enable_if_t<
+           std::is_void<Result>::value
+         >>
+always_ready_future<void>
+try_invoke(Function&& f)
+{
+  try
+  {
+    std::forward<Function>(f)();
+    return always_ready_future<void>();
+  }
+  catch(...)
+  {
+    return always_ready_future<void>(std::current_exception());
+  }
+}
+
+
+}
+

--- a/archetypes/always_ready_future/inline_executor.hpp
+++ b/archetypes/always_ready_future/inline_executor.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "always_ready_future.hpp"
+#include <type_traits>
+
+// inline_executor is an executor which always creates execution "inline"
+// Therefore, the execution it creates always blocks the execution of its client.
+
+class inline_executor
+{
+  public:
+    bool operator==(const inline_executor&) { return true; }
+    bool operator!=(const inline_executor&) { return false;}
+    const inline_executor& context() const { return *this; }
+
+    template<class T>
+    using future = always_ready_future<T>;
+
+    template<class Function>
+    auto sync_execute(Function&& f) const
+    {
+      std::forward<Function>(f)();
+    }
+
+    template<class Function>
+    future<std::result_of_t<std::decay_t<Function>()>>
+    twoway_execute(Function&& f) const
+    {
+      using result_type = std::result_of_t<std::decay_t<Function>()>;
+
+      try
+      {
+        return detail::try_invoke([&]
+        {
+          return sync_execute(std::forward<Function>(f));
+        });
+      }
+      catch(...)
+      {
+        return always_ready_future<result_type>(std::current_exception());
+      }
+    }
+
+    template<class Function, class Factory1, class Factory2>
+    auto bulk_sync_execute(Function f, size_t n, Factory1 result_factory, Factory2 shared_factory) const
+    {
+      auto result = result_factory();
+      auto shared = shared_factory();
+
+      for(size_t i = 0; i < n; ++i)
+      {
+        f(i, result, shared);
+      }
+
+      return result;
+    }
+
+    template<class Function, class Factory1, class Factory2>
+    future<std::result_of_t<Factory1()>>
+    bulk_twoway_execute(Function f, size_t n, Factory1 result_factory, Factory2 shared_factory) const
+    {
+      using result_type = std::result_of_t<Factory1()>;
+
+      try
+      {
+        return detail::try_invoke([&]
+        {
+          return bulk_sync_execute(f, n, result_factory, shared_factory);
+        });
+      }
+      catch(...)
+      {
+        return always_ready_future<result_type>(std::current_exception());
+      }
+    }
+};
+

--- a/archetypes/always_ready_future/optional.hpp
+++ b/archetypes/always_ready_future/optional.hpp
@@ -1,0 +1,560 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <utility>
+#include <type_traits>
+#include <stdexcept>
+#include <initializer_list>
+#include <functional>
+
+#ifndef __host__
+#  define __host__
+#  define OPTIONAL_UNDEF_HOST
+#endif
+
+#ifndef __device__
+#  define __device__
+#  define OPTIONAL_UNDEF_DEVICE
+#endif
+
+namespace std
+{
+namespace experimental
+{
+
+
+struct nullopt_t {};
+constexpr nullopt_t nullopt{};
+
+struct in_place_t {};
+constexpr in_place_t in_place{};
+
+
+class bad_optional_access : public std::logic_error
+{
+  public:
+    explicit bad_optional_access(const std::string& what_arg) : logic_error(what_arg) {}
+    explicit bad_optional_access(const char* what_arg) : logic_error(what_arg) {}
+};
+
+
+namespace detail
+{
+
+
+__host__ __device__
+inline void throw_bad_optional_access(const char* what_arg)
+{
+#ifdef __CUDA_ARCH__
+  printf("bad_optional_access: %s\n", what_arg);
+  assert(0);
+#else
+  throw bad_optional_access(what_arg);
+#endif
+}
+
+
+#pragma nv_exec_check_disable
+template<class T>
+__host__ __device__
+static void optional_swap(T& a, T& b)
+{
+  using std::swap;
+  swap(a,b);
+}
+
+
+template<
+  class T,
+  bool use_empty_base_class_optimization =
+    std::is_empty<T>::value
+#if __cplusplus >= 201402L
+    && !std::is_final<T>::value
+#endif
+>
+struct optional_base
+{
+  typedef typename std::aligned_storage<
+    sizeof(T)
+  >::type storage_type;
+  
+  storage_type storage_;
+};
+
+template<class T>
+struct optional_base<T,true> : T {};
+
+
+} // end detail
+
+
+template<class T>
+class optional : public detail::optional_base<T>
+{
+  public:
+    __host__ __device__
+    optional(nullopt_t) : has_value_{false} {}
+
+    __host__ __device__
+    optional() : optional(nullopt) {}
+
+    __host__ __device__
+    optional(const optional& other)
+      : has_value_(other.has_value_)
+    {
+      emplace(*other);
+    }
+
+    __host__ __device__
+    optional(optional&& other)
+      : has_value_(false)
+    {
+      if(other)
+      {
+        emplace(std::move(*other));
+      }
+    }
+
+    __host__ __device__
+    optional(const T& value)
+      : has_value_(false)
+    {
+      emplace(value);
+    }
+
+    __host__ __device__
+    optional(T&& value)
+      : optional(in_place, std::forward<T>(value))
+    {
+    }
+
+    template<class... Args>
+    __host__ __device__
+    optional(in_place_t, Args&&... args)
+      : has_value_(false)
+    {
+      emplace(std::forward<Args>(args)...);
+    }
+
+    template<class U, class... Args,
+             class = typename std::enable_if<
+               std::is_constructible<T, std::initializer_list<U>&, Args&&...>::value
+             >::type>
+    __host__ __device__
+    optional(in_place_t, std::initializer_list<U> ilist, Args&&... args)
+      : has_value_(false)
+    {
+      emplace(ilist, std::forward<Args>(args)...);
+    }
+
+    __host__ __device__
+    ~optional()
+    {
+      reset();
+    }
+
+    __host__ __device__
+    optional& operator=(nullopt_t)
+    {
+      reset();
+      return *this;
+    }
+
+    __host__ __device__
+    optional& operator=(const optional& other)
+    {
+      if(other)
+      {
+        *this = *other;
+      }
+      else
+      {
+        *this = nullopt;
+      }
+
+      return *this;
+    }
+
+    __host__ __device__
+    optional& operator=(optional&& other)
+    {
+      if(other)
+      {
+        *this = std::move(*other);
+      }
+      else
+      {
+        *this = nullopt;
+      }
+
+      return *this;
+    }
+
+    template<class U,
+             class = typename std::enable_if<
+               std::is_same<typename std::decay<U>::type,T>::value
+             >::type>
+    __host__ __device__
+    optional& operator=(U&& value)
+    {
+      if(*this)
+      {
+        **this = std::forward<U>(value);
+      }
+      else
+      {
+        emplace(std::forward<U>(value));
+      }
+
+      return *this;
+    }
+
+    template<class... Args>
+    __host__ __device__
+    void emplace(Args&&... args)
+    {
+      reset();
+
+      new (operator->()) T(std::forward<Args>(args)...);
+      has_value_ = true;
+    }
+
+    template<class U, class... Args,
+             class = typename std::enable_if<
+               std::is_constructible<T,std::initializer_list<U>&, Args&&...>::value
+             >::type>
+    __host__ __device__
+    void emplace(std::initializer_list<U> ilist, Args&&... args)
+    {
+      reset();
+
+      new (operator->()) T(ilist, std::forward<Args>(args)...);
+      has_value_ = true;
+    }
+
+    __host__ __device__
+    explicit operator bool() const
+    {
+      return has_value_;
+    }
+
+    __host__ __device__
+    T& value() &
+    {
+      if(!*this)
+      {
+        detail::throw_bad_optional_access("optional::value(): optional does not contain a value");
+      }
+
+      return **this;
+    }
+
+    __host__ __device__
+    const T& value() const &
+    {
+      if(!*this)
+      {
+        detail::throw_bad_optional_access("optional::value(): optional does not contain a value");
+      }
+
+      return **this;
+    }
+
+    __host__ __device__
+    T&& value() &&
+    {
+      if(!*this)
+      {
+        detail::throw_bad_optional_access("optional::value(): optional does not contain a value");
+      }
+
+      return std::move(**this);
+    }
+
+    __host__ __device__
+    const T&& value() const &&
+    {
+      if(!*this)
+      {
+        detail::throw_bad_optional_access("optional::value(): optional does not contain a value");
+      }
+
+      return std::move(**this);
+    }
+
+    template<class U>
+    __host__ __device__
+    T value_or(U&& default_value) const &
+    {
+      return bool(*this) ? **this : static_cast<T>(std::forward<U>(default_value));
+    }
+
+    template<class U>
+    __host__ __device__
+    T value_or(U&& default_value) &&
+    {
+      return bool(*this) ? std::move(**this) : static_cast<T>(std::forward<U>(default_value));
+    }
+
+    __host__ __device__
+    void swap(optional& other)
+    {
+      if(other)
+      {
+        if(*this)
+        {
+          detail::optional_swap(**this, *other);
+        }
+        else
+        {
+          emplace(*other);
+          other = nullopt;
+        }
+      }
+      else
+      {
+        if(*this)
+        {
+          other.emplace(**this);
+          *this = nullopt;
+        }
+        else
+        {
+          // no effect
+        }
+      }
+    }
+
+    __host__ __device__
+    const T* operator->() const
+    {
+      return reinterpret_cast<const T*>(this);
+    }
+
+    __host__ __device__
+    T* operator->()
+    {
+      return reinterpret_cast<T*>(this);
+    }
+
+    __host__ __device__
+    const T& operator*() const &
+    {
+      return *operator->();
+    }
+
+    __host__ __device__
+    T& operator*() &
+    {
+      return *operator->();
+    }
+
+    __host__ __device__
+    const T&& operator*() const &&
+    {
+      return *operator->();
+    }
+
+    __host__ __device__
+    T&& operator*() &&
+    {
+      return *operator->();
+    }
+
+    __host__ __device__
+    void reset()
+    {
+      if(*this)
+      {
+        (**this).~T();
+        has_value_ = false;
+      }
+    }
+
+  private:
+    bool has_value_;
+};
+
+
+// comparison
+template<class T>
+__host__ __device__
+bool operator==(const optional<T>& lhs, const optional<T>& rhs)
+{
+  if(lhs && rhs)
+  {
+    return *lhs == *rhs;
+  }
+
+  return bool(lhs) == bool(rhs);
+}
+
+
+template<class T>
+__host__ __device__
+bool operator<(const optional<T>& lhs, const optional<T>& rhs)
+{
+  if(lhs && rhs)
+  {
+    return *lhs < *rhs;
+  }
+
+  return !bool(lhs) && bool(rhs);
+}
+
+
+// comparison with nullopt_t
+template<class T>
+__host__ __device__
+bool operator==(const optional<T>& lhs, nullopt_t)
+{
+  return lhs == optional<T>(nullopt);
+}
+
+template<class T>
+__host__ __device__
+bool operator==(nullopt_t, const optional<T>& rhs)
+{
+  return optional<T>(nullopt) == rhs;
+}
+
+
+template<class T>
+__host__ __device__
+bool operator<(const optional<T>& lhs, nullopt_t)
+{
+  return lhs < optional<T>(nullopt);
+}
+
+
+template<class T>
+__host__ __device__
+bool operator<(nullopt_t, const optional<T>& rhs)
+{
+  return optional<T>(nullopt) < rhs;
+}
+
+
+// comparison with T
+template<class T>
+__host__ __device__
+bool operator==(const optional<T>& lhs, const T& rhs)
+{
+  if(lhs)
+  {
+    return *lhs == rhs;
+  }
+
+  return false;
+}
+
+
+template<class T>
+__host__ __device__
+bool operator==(const T& lhs, const optional<T>& rhs)
+{
+  if(rhs)
+  {
+    return lhs == *rhs;
+  }
+
+  return false;
+}
+
+
+template<class T>
+__host__ __device__
+bool operator<(const optional<T>& lhs, const T& rhs)
+{
+  if(lhs)
+  {
+    return *lhs < rhs;
+  }
+
+  return true;
+}
+
+template<class T>
+__host__ __device__
+bool operator<(const T& lhs, const optional<T>& rhs)
+{
+  if(rhs)
+  {
+    return lhs < *rhs;
+  }
+
+  return false;
+}
+
+
+
+template<class T>
+__host__ __device__
+optional<typename std::decay<T>::type> make_optional(T&& value)
+{
+  return optional<typename std::decay<T>::type>(std::forward<T>(value));
+}
+
+
+} // end experimental
+
+
+template<class T>
+__host__ __device__
+void swap(experimental::optional<T>& a, experimental::optional<T>& b)
+{
+  a.swap(b);
+}
+
+
+template<class>
+struct hash;
+
+template<class T>
+struct hash<experimental::optional<T>>
+{
+  #pragma nv_exec_check_disable
+  __host__ __device__
+  size_t operator()(const experimental::optional<T>& key) const
+  {
+    return bool(key) ? std::hash<T>()(*key) : size_t(0);
+  }
+};
+
+} // end std
+
+#ifdef OPTIONAL_UNDEF_HOST
+#  undef __host__
+#  undef OPTIONAL_UNDEF_HOST
+#endif
+
+#ifdef OPTIONAL_UNDEF_DEVICE
+#  undef __device__
+#  undef OPTIONAL_UNDEF_DEVICE
+#endif
+

--- a/archetypes/always_ready_future/saxpy.cpp
+++ b/archetypes/always_ready_future/saxpy.cpp
@@ -1,0 +1,222 @@
+// This example is meant to demonstrate that the legacy .sync_execute() and .bulk_sync_execute() execution functions
+// are made obsolete by always_ready_future. Observe that the performance of all the SAXPY variants in this example program
+// are similar because always_ready_future introduces negligible overhead.
+
+#include <iostream>
+#include <chrono>
+#include <tuple>
+#include <cassert>
+#include <vector>
+
+#include "inline_executor.hpp"
+
+void for_loop_saxpy(float a,
+                    const std::vector<float>& x,
+                    const std::vector<float>& y,
+                    std::vector<float>& z)
+{
+  for(size_t i = 0; i < x.size(); ++i)
+  {
+    z[i] = a * x[i] + y[i];
+  }
+}
+
+void sync_execute_saxpy(float a,
+                        const std::vector<float>& x,
+                        const std::vector<float>& y,
+                        std::vector<float>& z)
+{
+  inline_executor exec;
+
+  for(size_t i = 0; i < x.size(); ++i)
+  {
+    exec.sync_execute([&]
+    {
+      z[i] = a * x[i] + y[i];
+    });
+  }
+}
+
+void twoway_execute_saxpy(float a,
+                          const std::vector<float>& x,
+                          const std::vector<float>& y,
+                          std::vector<float>& z)
+{
+  inline_executor exec;
+
+  for(size_t i = 0; i < x.size(); ++i)
+  {
+    exec.twoway_execute([&]
+    {
+      z[i] = a * x[i] + y[i];
+    }).wait();
+  }
+}
+
+void bulk_sync_execute_saxpy(float a,
+                             const std::vector<float>& x,
+                             const std::vector<float>& y,
+                             std::vector<float>& z)
+{
+  inline_executor exec;
+
+  exec.bulk_sync_execute([&](size_t i, auto, auto)
+  {
+    z[i] = a * x[i] + y[i];
+  },
+  x.size(),
+  []{ return std::ignore; },
+  []{ return std::ignore; }
+  );
+}
+
+void bulk_twoway_execute_saxpy(float a,
+                               const std::vector<float>& x,
+                               const std::vector<float>& y,
+                               std::vector<float>& z)
+{
+  inline_executor exec;
+
+  exec.bulk_twoway_execute([&](size_t i, auto, auto)
+  {
+    z[i] = a * x[i] + y[i];
+  },
+  x.size(),
+  []{ return std::ignore; },
+  []{ return std::ignore; }
+  ).wait();
+}
+
+int main()
+{
+  size_t num_trials = 100;
+
+  size_t n = 1 << 25;
+
+  float a = 42;
+  std::vector<float> x(n, 7);
+  std::vector<float> y(n, 13);
+  std::vector<float> z(n);
+
+  std::vector<float> reference(n, 42 * 7 + 13);
+
+  std::cout << "SAXPY problem size: " << n << std::endl;
+
+  {
+    // make sure it works
+    for_loop_saxpy(a, x, y, z);
+    assert(z == reference);
+
+    // warm-up
+    for_loop_saxpy(a, x, y, z);
+
+    auto start = std::chrono::high_resolution_clock::now();
+    for(size_t i = 0; i < num_trials; ++i)
+    {
+      for_loop_saxpy(a, x, y, z);
+    }
+
+    std::chrono::duration<double> elapsed = std::chrono::high_resolution_clock::now() - start;
+
+    double seconds = elapsed.count() / num_trials;
+    double gigabytes = double(3 * n * sizeof(float)) / (1 << 30);
+    double bandwidth = gigabytes / seconds;
+
+    std::cout << "for_loop_saxpy (reference): " << bandwidth << " GB/s" << std::endl;
+  }
+
+  {
+    // make sure it works
+    sync_execute_saxpy(a, x, y, z);
+    assert(z == reference);
+
+    // warm-up
+    sync_execute_saxpy(a, x, y, z);
+
+    auto start = std::chrono::high_resolution_clock::now();
+    for(size_t i = 0; i < num_trials; ++i)
+    {
+      sync_execute_saxpy(a, x, y, z);
+    }
+
+    std::chrono::duration<double> elapsed = std::chrono::high_resolution_clock::now() - start;
+
+    double seconds = elapsed.count() / num_trials;
+    double gigabytes = double(3 * n * sizeof(float)) / (1 << 30);
+    double bandwidth = gigabytes / seconds;
+
+    std::cout << "sync_execute_saxpy: " << bandwidth << " GB/s" << std::endl;
+  }
+
+  {
+    // make sure it works
+    twoway_execute_saxpy(a, x, y, z);
+    assert(z == reference);
+
+    // warm-up
+    twoway_execute_saxpy(a, x, y, z);
+
+    auto start = std::chrono::high_resolution_clock::now();
+    for(size_t i = 0; i < num_trials; ++i)
+    {
+      twoway_execute_saxpy(a, x, y, z);
+    }
+
+    std::chrono::duration<double> elapsed = std::chrono::high_resolution_clock::now() - start;
+
+    double seconds = elapsed.count() / num_trials;
+    double gigabytes = double(3 * n * sizeof(float)) / (1 << 30);
+    double bandwidth = gigabytes / seconds;
+
+    std::cout << "twoway_execute_saxpy: " << bandwidth << " GB/s" << std::endl;
+  }
+
+  {
+    // make sure it works
+    bulk_sync_execute_saxpy(a, x, y, z);
+    assert(z == reference);
+
+    // warm-up
+    bulk_sync_execute_saxpy(a, x, y, z);
+
+    auto start = std::chrono::high_resolution_clock::now();
+    for(size_t i = 0; i < num_trials; ++i)
+    {
+      bulk_sync_execute_saxpy(a, x, y, z);
+    }
+
+    std::chrono::duration<double> elapsed = std::chrono::high_resolution_clock::now() - start;
+
+    double seconds = elapsed.count() / num_trials;
+    double gigabytes = double(3 * n * sizeof(float)) / (1 << 30);
+    double bandwidth = gigabytes / seconds;
+
+    std::cout << "bulk_sync_execute_saxpy: " << bandwidth << " GB/s" << std::endl;
+  }
+
+  {
+    // make sure it works
+    bulk_twoway_execute_saxpy(a, x, y, z);
+    assert(z == reference);
+
+    // warm-up
+    bulk_twoway_execute_saxpy(a, x, y, z);
+
+    auto start = std::chrono::high_resolution_clock::now();
+    for(size_t i = 0; i < num_trials; ++i)
+    {
+      bulk_twoway_execute_saxpy(a, x, y, z);
+    }
+
+    std::chrono::duration<double> elapsed = std::chrono::high_resolution_clock::now() - start;
+
+    double seconds = elapsed.count() / num_trials;
+    double gigabytes = double(3 * n * sizeof(float)) / (1 << 30);
+    double bandwidth = gigabytes / seconds;
+
+    std::cout << "bulk_twoway_execute_saxpy: " << bandwidth << " GB/s" << std::endl;
+  }
+
+  return 0;
+}
+

--- a/archetypes/always_ready_future/variant.hpp
+++ b/archetypes/always_ready_future/variant.hpp
@@ -1,0 +1,1045 @@
+// Copyright (c) 2015, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <type_traits>
+#include <iostream>
+#include <cassert>
+#include <stdexcept>
+#include <string>
+#include <cstdio>
+
+#ifndef __host__
+#  define __host__
+#  define VARIANT_UNDEF_HOST
+#endif
+
+#ifndef __device__
+#  define __device__
+#  define VARIANT_UNDEF_DEVICE
+#endif
+
+
+namespace std
+{
+namespace experimental
+{
+namespace detail
+{
+
+
+template<size_t i, size_t... js>
+struct constexpr_max
+{
+  static const size_t value = i < constexpr_max<js...>::value ? constexpr_max<js...>::value : i;
+};
+
+
+template<size_t i>
+struct constexpr_max<i>
+{
+  static const size_t value = i;
+};
+
+
+} // end detail
+
+
+template<typename... Types>
+class variant;
+
+
+namespace detail
+{
+
+template<size_t i, typename Variant> struct variant_element;
+
+
+template<size_t i, typename T0, typename... Types>
+struct variant_element<i, variant<T0, Types...>>
+  : variant_element<i-1,variant<Types...>>
+{};
+
+
+template<typename T0, typename... Types>
+struct variant_element<0, variant<T0, Types...>>
+{
+  typedef T0 type;
+};
+
+
+template<size_t i, typename... Types>
+using variant_element_t = typename variant_element<i,Types...>::type;
+
+
+} // end detail
+
+
+static constexpr const size_t variant_not_found = static_cast<size_t>(-1);
+
+
+namespace detail
+{
+
+
+template<typename T, typename U>
+struct propagate_reference;
+
+
+template<typename T, typename U>
+struct propagate_reference<T&, U>
+{
+  typedef U& type;
+};
+
+
+template<typename T, typename U>
+struct propagate_reference<const T&, U>
+{
+  typedef const U& type;
+};
+
+
+template<typename T, typename U>
+struct propagate_reference<T&&, U>
+{
+  typedef U&& type;
+};
+
+
+template<size_t i, typename VariantReference>
+struct variant_element_reference
+  : propagate_reference<
+      VariantReference,
+      variant_element_t<
+        i,
+        typename std::decay<VariantReference>::type
+      >
+    >
+{};
+
+
+template<size_t i, typename VariantReference>
+using variant_element_reference_t = typename variant_element_reference<i,VariantReference>::type;
+
+
+} // end detail
+
+
+template<typename Visitor, typename Variant>
+__host__ __device__
+typename std::result_of<
+  Visitor&(detail::variant_element_reference_t<0,Variant&&>)
+>::type
+  visit(Visitor& visitor, Variant&& var);
+
+
+template<typename Visitor, typename Variant>
+__host__ __device__
+typename std::result_of<
+  const Visitor&(detail::variant_element_reference_t<0,Variant&&>)
+>::type
+  visit(const Visitor& visitor, Variant&& var);
+
+
+template<typename Visitor, typename Variant1, typename Variant2>
+__host__ __device__
+typename std::result_of<
+  Visitor&(detail::variant_element_reference_t<0,Variant1&&>,
+           detail::variant_element_reference_t<0,Variant2&&>)
+>::type
+  visit(Visitor& visitor, Variant1&& var1, Variant2&& var2);
+
+
+template<typename Visitor, typename Variant1, typename Variant2>
+__host__ __device__
+typename std::result_of<
+  const Visitor&(detail::variant_element_reference_t<0,Variant1&&>,
+                 detail::variant_element_reference_t<0,Variant2&&>)
+>::type
+  visit(const Visitor& visitor, Variant1&& var1, Variant2&& var2);
+
+
+namespace detail
+{
+
+
+template<size_t i, typename T, typename... Types>
+struct find_type_impl;
+
+
+// no match, keep going
+template<size_t i, typename T, typename U, typename... Types>
+struct find_type_impl<i,T,U,Types...>
+  : find_type_impl<i+1,T,Types...>
+{};
+
+
+// found a match
+template<size_t i, typename T, typename... Types>
+struct find_type_impl<i,T,T,Types...>
+{
+  static constexpr const size_t value = i;
+};
+
+
+// no match
+template<size_t i, typename T>
+struct find_type_impl<i,T>
+{
+  static constexpr const size_t value = variant_not_found;
+};
+
+
+template<typename T, typename... Types>
+using find_type = find_type_impl<0,T,Types...>;
+
+
+template<typename T, typename Variant>
+struct is_variant_alternative;
+
+template<class T, class... Types>
+struct is_variant_alternative<T,variant<Types...>>
+  : std::integral_constant<
+      bool,
+      (find_type<T,Types...>::value != variant_not_found)
+    >
+{};
+
+
+} // end detail
+
+
+class bad_variant_access : public std::logic_error
+{
+  public:
+    explicit bad_variant_access(const std::string& what_arg) : logic_error(what_arg) {}
+    explicit bad_variant_access(const char* what_arg) : logic_error(what_arg) {}
+};
+
+
+namespace detail
+{
+
+
+__host__ __device__
+inline void throw_bad_variant_access(const char* what_arg)
+{
+#ifdef __CUDA_ARCH__
+  printf("bad_variant_access: %s\n", what_arg);
+  assert(0);
+#else
+  throw bad_variant_access(what_arg);
+#endif
+}
+
+
+template<class T, class...>
+struct first_type
+{
+  using type = T;
+};
+
+template<class... Types>
+using first_type_t = typename first_type<Types...>::type;
+
+
+template<class... Types>
+class variant_storage
+{
+  typedef typename std::aligned_storage<
+    constexpr_max<sizeof(Types)...>::value
+  >::type storage_type;
+  
+  storage_type storage_;
+};
+
+template<>
+class variant_storage<> {};
+
+} // end detail
+
+
+template<typename... Types>
+class variant : private detail::variant_storage<Types...>
+{
+  public:
+    __host__ __device__
+    variant()
+      : variant(detail::first_type_t<Types...>{})
+    {}
+
+  private:
+    struct binary_move_construct_visitor
+    {
+      template<class T>
+      __host__ __device__
+      void operator()(T& self, T& other)
+      {
+        new (&self) T(std::move(other));
+      }
+
+      template<class... Args>
+      __host__ __device__
+      void operator()(Args&&...){}
+    };
+
+  public:
+    __host__ __device__
+    variant(variant&& other)
+      : index_(other.index())
+    {
+      auto visitor = binary_move_construct_visitor();
+      std::experimental::visit(visitor, *this, other);
+    }
+
+  private:
+    struct binary_copy_construct_visitor
+    {
+      template<class T>
+      __host__ __device__
+      void operator()(T& self, const T& other) const
+      {
+        new (&self) T(other);
+      }
+
+      template<class... Args>
+      __host__ __device__
+      void operator()(Args&&...) const {}
+    };
+
+  public:
+    __host__ __device__
+    variant(const variant& other)
+      : index_(other.index())
+    {
+      auto visitor = binary_copy_construct_visitor();
+      std::experimental::visit(visitor, *this, other);
+    }
+
+  private:
+    template<class T>
+    struct unary_copy_construct_visitor
+    {
+      const T& other;
+
+      __host__ __device__
+      void operator()(T& self) const
+      {
+        new (&self) T(other);
+      }
+
+      template<class U>
+      __host__ __device__
+      void operator()(U&&) const {}
+    };
+
+  public:
+    template<class T,
+             class = typename std::enable_if<
+               detail::is_variant_alternative<T,variant>::value
+             >::type>
+    __host__ __device__
+    variant(const T& other)
+      : index_(detail::find_type<T,Types...>::value)
+    {
+      std::experimental::visit(unary_copy_construct_visitor<T>{other}, *this);
+    }
+
+  private:
+    template<class T>
+    struct unary_move_construct_visitor
+    {
+      T& other;
+
+      __host__ __device__
+      void operator()(T& self)
+      {
+        new (&self) T(std::move(other));
+      }
+
+      template<class U>
+      __host__ __device__
+      void operator()(U&&){}
+    };
+
+  public:
+    template<class T,
+             class = typename std::enable_if<
+               detail::is_variant_alternative<T,variant>::value
+             >::type>
+    __host__ __device__
+    variant(T&& other)
+      : index_(detail::find_type<T,Types...>::value)
+    {
+      auto visitor = unary_move_construct_visitor<T>{other};
+      std::experimental::visit(visitor, *this);
+    }
+
+  private:
+    struct destruct_visitor
+    {
+      template<typename T>
+      __host__ __device__
+      typename std::enable_if<
+        !std::is_trivially_destructible<T>::value
+      >::type
+        operator()(T& x)
+      {
+        x.~T();
+      }
+      
+      template<typename T>
+      __host__ __device__
+      typename std::enable_if<
+        std::is_trivially_destructible<T>::value
+      >::type
+        operator()(T&)
+      {
+        // omit invocations of destructors for trivially destructible types
+      }
+    };
+
+  public:
+    __host__ __device__
+    ~variant()
+    {
+      auto visitor = destruct_visitor();
+      std::experimental::visit(visitor, *this);
+    }
+
+  private:
+    struct copy_assign_visitor
+    {
+      template<class T>
+      __host__ __device__
+      void operator()(T& self, const T& other) const
+      {
+        self = other;
+      }
+
+      template<class... Args>
+      __host__ __device__
+      void operator()(Args&&...) const {}
+    };
+
+    struct destroy_and_copy_construct_visitor
+    {
+      template<class A, class B>
+      __host__ __device__
+      void operator()(A& a, const B& b) const
+      {
+        // copy b to a temporary
+        B tmp = b;
+
+        // destroy a
+        a.~A();
+
+        // placement move from tmp to a
+        new (&a) B(std::move(tmp));
+      }
+    };
+
+    struct destroy_and_move_construct_visitor
+    {
+      template<class A, class B>
+      __host__ __device__
+      void operator()(A& a, B&& b) const
+      {
+        // destroy a
+        a.~A();
+
+        using type = typename std::decay<B>::type;
+
+        // placement move from b
+        new (&a) type(std::move(b));
+      }
+    };
+
+  public:
+    __host__ __device__
+    variant& operator=(const variant& other)
+    {
+      if(index() == other.index())
+      {
+        std::experimental::visit(copy_assign_visitor(), *this, other);
+      }
+      else
+      {
+        std::experimental::visit(destroy_and_copy_construct_visitor(), *this, other);
+        index_ = other.index();
+      }
+
+      return *this;
+    }
+
+  private:
+    struct move_assign_visitor
+    {
+      template<class T>
+      __host__ __device__
+      void operator()(T& self, T& other)
+      {
+        self = std::move(other);
+      }
+
+      template<class... Args>
+      __host__ __device__
+      void operator()(Args&&...){}
+    };
+
+
+  public:
+    __host__ __device__
+    variant& operator=(variant&& other)
+    {
+      if(index() == other.index())
+      {
+        auto visitor = move_assign_visitor();
+        std::experimental::visit(visitor, *this, other);
+      }
+      else
+      {
+        auto visitor = destroy_and_move_construct_visitor();
+        std::experimental::visit(visitor, *this, std::move(other));
+        index_ = other.index();
+      }
+
+      return *this;
+    }
+
+    __host__ __device__
+    size_t index() const
+    {
+      return index_;
+    }
+
+  private:
+    struct swap_visitor
+    {
+      template<class A, class B>
+      __host__ __device__
+      void operator()(A& a, B& b)
+      {
+        // XXX can't call std::swap because __host__ __device__
+        A tmp = std::move(a);
+        a = std::move(b);
+        b = std::move(tmp);
+      }
+    };
+
+  public:
+    __host__ __device__
+    void swap(variant& other)
+    {
+      if(index() == other.index())
+      {
+        auto visitor = swap_visitor();
+        std::experimental::visit(visitor, *this, other);
+      }
+      else
+      {
+        variant tmp = *this;
+        *this = other;
+        other = std::move(tmp);
+      }
+    }
+
+  private:
+    struct equals
+    {
+      template<typename U1, typename U2>
+      __host__ __device__
+      bool operator()(const U1&, const U2&)
+      {
+        return false;
+      }
+
+      template<typename T>
+      __host__ __device__
+      bool operator()(const T& lhs, const T& rhs)
+      {
+        return lhs == rhs;
+      }
+    };
+
+
+  public:
+    __host__ __device__
+    bool operator==(const variant& rhs) const
+    {
+      auto visitor = equals();
+      return index() == rhs.index() && std::experimental::visit(visitor, *this, rhs);
+    }
+
+    __host__ __device__
+    bool operator!=(const variant& rhs) const
+    {
+      return !operator==(rhs);
+    }
+
+  private:
+    struct less
+    {
+      template<typename U1, typename U2>
+      __host__ __device__
+      bool operator()(const U1&, const U2&)
+      {
+        return false;
+      }
+
+      template<typename T>
+      __host__ __device__
+      bool operator()(const T& lhs, const T& rhs)
+      {
+        return lhs < rhs;
+      }
+    };
+
+  public:
+    __host__ __device__
+    bool operator<(const variant& rhs) const
+    {
+      if(index() != rhs.index()) return index() < rhs.index();
+
+      return std::experimental::visit(less(), *this, rhs);
+    }
+
+    __host__ __device__
+    bool operator<=(const variant& rhs) const
+    {
+      return !(rhs < *this);
+    }
+
+    __host__ __device__
+    bool operator>(const variant& rhs) const
+    {
+      return rhs < *this;
+    }
+
+    __host__ __device__
+    bool operator>=(const variant& rhs) const
+    {
+      return !(*this < rhs);
+    }
+
+  private:
+    size_t index_;
+};
+
+
+namespace detail
+{
+
+
+struct ostream_output_visitor
+{
+  std::ostream &os;
+
+  ostream_output_visitor(std::ostream& os) : os(os) {}
+
+  template<typename T>
+  std::ostream& operator()(const T& x)
+  {
+    return os << x;
+  }
+};
+
+
+} // detail
+
+
+template<typename... Types>
+std::ostream &operator<<(std::ostream& os, const variant<Types...>& v)
+{
+  auto visitor = detail::ostream_output_visitor(os);
+  return std::experimental::visit(visitor, v);
+}
+
+
+namespace detail
+{
+
+
+template<typename VisitorReference, typename Result, typename T, typename... Types>
+struct apply_visitor_impl : apply_visitor_impl<VisitorReference,Result,Types...>
+{
+  typedef apply_visitor_impl<VisitorReference,Result,Types...> super_t;
+
+  __host__ __device__
+  static Result do_it(VisitorReference visitor, void* ptr, size_t index)
+  {
+    if(index == 0)
+    {
+      return visitor(*reinterpret_cast<T*>(ptr));
+    }
+
+    return super_t::do_it(visitor, ptr, --index);
+  }
+
+
+  __host__ __device__
+  static Result do_it(VisitorReference visitor, const void* ptr, size_t index)
+  {
+    if(index == 0)
+    {
+      return visitor(*reinterpret_cast<const T*>(ptr));
+    }
+
+    return super_t::do_it(visitor, ptr, --index);
+  }
+};
+
+
+template<typename VisitorReference, typename Result, typename T>
+struct apply_visitor_impl<VisitorReference,Result,T>
+{
+  __host__ __device__
+  static Result do_it(VisitorReference visitor, void* ptr, size_t)
+  {
+    return visitor(*reinterpret_cast<T*>(ptr));
+  }
+
+  __host__ __device__
+  static Result do_it(VisitorReference visitor, const void* ptr, size_t)
+  {
+    return visitor(*reinterpret_cast<const T*>(ptr));
+  }
+};
+
+
+template<typename VisitorReference, typename Result, typename Variant>
+struct apply_visitor;
+
+
+template<typename VisitorReference, typename Result, typename... Types>
+struct apply_visitor<VisitorReference,Result,variant<Types...>>
+  : apply_visitor_impl<VisitorReference,Result,Types...>
+{};
+
+
+} // end detail
+
+
+template<typename Visitor, typename Variant>
+__host__ __device__
+typename std::result_of<
+  Visitor&(detail::variant_element_reference_t<0,Variant&&>)
+>::type
+  visit(Visitor& visitor, Variant&& var)
+{
+  using result_type = typename std::result_of<
+    Visitor&(detail::variant_element_reference_t<0,Variant&&>)
+  >::type;
+
+  using impl = detail::apply_visitor<Visitor&,result_type,typename std::decay<Variant>::type>;
+
+  return impl::do_it(visitor, &var, var.index());
+}
+
+
+template<typename Visitor, typename Variant>
+__host__ __device__
+typename std::result_of<
+  const Visitor&(detail::variant_element_reference_t<0,Variant&&>)
+>::type
+  visit(const Visitor& visitor, Variant&& var)
+{
+  using result_type = typename std::result_of<
+    const Visitor&(detail::variant_element_reference_t<0,Variant&&>)
+  >::type;
+ 
+  using impl = detail::apply_visitor<const Visitor&,result_type,typename std::decay<Variant>::type>;
+
+  return impl::do_it(visitor, &var, var.index());
+}
+
+
+namespace detail
+{
+
+
+template<typename VisitorReference, typename Result, typename ElementReference>
+struct unary_visitor_binder
+{
+  VisitorReference visitor;
+  ElementReference x;
+
+  __host__ __device__
+  unary_visitor_binder(VisitorReference visitor, ElementReference x) : visitor(visitor), x(x) {}
+
+  template<typename T>
+  __host__ __device__
+  Result operator()(T&& y)
+  {
+    return visitor(x, std::forward<T>(y));
+  }
+};
+
+
+template<class Reference>
+struct rvalue_reference_to_lvalue_reference
+{
+  using type = Reference;
+};
+
+template<class T>
+struct rvalue_reference_to_lvalue_reference<T&&>
+{
+  using type = T&;
+};
+
+
+template<typename VisitorReference, typename Result, typename VariantReference>
+struct binary_visitor_binder
+{
+  VisitorReference visitor;
+  // since rvalue references can't be members of classes, we transform any
+  // VariantReference which is an rvalue reference to an lvalue reference
+  // when we use y in operator(), we cast it back to the original reference type
+  typename rvalue_reference_to_lvalue_reference<VariantReference>::type y;
+
+  __host__ __device__
+  binary_visitor_binder(VisitorReference visitor, VariantReference ref) : visitor(visitor), y(ref) {}
+
+  template<typename T>
+  __host__ __device__
+  Result operator()(T&& x)
+  {
+    auto unary_visitor = unary_visitor_binder<VisitorReference, Result, decltype(x)>(visitor, std::forward<T>(x));
+    return std::experimental::visit(unary_visitor, std::forward<VariantReference>(y));
+  }
+};
+
+
+} // end detail
+
+
+template<typename Visitor, typename Variant1, typename Variant2>
+__host__ __device__
+typename std::result_of<
+  Visitor&(detail::variant_element_reference_t<0,Variant1&&>,
+           detail::variant_element_reference_t<0,Variant2&&>)
+>::type
+  visit(Visitor& visitor, Variant1&& var1, Variant2&& var2)
+{
+  using result_type = typename std::result_of<
+    Visitor&(detail::variant_element_reference_t<0,Variant1&&>,
+             detail::variant_element_reference_t<0,Variant2&&>)
+  >::type;
+
+  auto visitor_wrapper = detail::binary_visitor_binder<Visitor&,result_type,decltype(var2)>(visitor, std::forward<Variant2>(var2));
+
+  return std::experimental::visit(visitor_wrapper, std::forward<Variant1>(var1));
+}
+
+
+template<typename Visitor, typename Variant1, typename Variant2>
+__host__ __device__
+typename std::result_of<
+  const Visitor&(detail::variant_element_reference_t<0,Variant1&&>,
+                 detail::variant_element_reference_t<0,Variant2&&>)
+>::type
+  visit(const Visitor& visitor, Variant1&& var1, Variant2&& var2)
+{
+  using result_type = typename std::result_of<
+    const Visitor&(detail::variant_element_reference_t<0,Variant1&&>,
+                   detail::variant_element_reference_t<0,Variant2&&>)
+  >::type;
+
+  auto visitor_wrapper = detail::binary_visitor_binder<const Visitor&,result_type,decltype(var2)>(visitor, std::forward<Variant2>(var2));
+
+  return std::experimental::visit(visitor_wrapper, std::forward<Variant1>(var1));
+}
+
+
+namespace detail
+{
+
+
+template<class T>
+struct get_visitor
+{
+  __host__ __device__
+  T* operator()(T& x) const
+  {
+    return &x;
+  }
+
+  __host__ __device__
+  const T* operator()(const T& x) const
+  {
+    return &x;
+  }
+
+  template<class U>
+  __host__ __device__
+  T* operator()(U&&) const
+  {
+    return nullptr;
+  }
+};
+
+} // end detail
+
+
+template<size_t i, class... Types>
+__host__ __device__
+detail::variant_element_reference_t<i, variant<Types...>&>
+  get(variant<Types...>& v)
+{
+  if(i != v.index())
+  {
+    detail::throw_bad_variant_access("i does not equal index()");
+  }
+
+  using type = typename std::decay<
+    detail::variant_element_t<i,variant<Types...>>
+  >::type;
+
+  auto visitor = detail::get_visitor<type>();
+  return *std::experimental::visit(visitor, v);
+}
+
+
+template<size_t i, class... Types>
+__host__ __device__
+detail::variant_element_reference_t<i, variant<Types...>&&>
+  get(variant<Types...>&& v)
+{
+  if(i != v.index())
+  {
+    detail::throw_bad_variant_access("i does not equal index()");
+  }
+
+  using type = typename std::decay<
+    detail::variant_element_t<i,variant<Types...>>
+  >::type;
+
+  auto visitor = detail::get_visitor<type>();
+  return std::move(*std::experimental::visit(visitor, v));
+}
+
+
+template<size_t i, class... Types>
+__host__ __device__
+detail::variant_element_reference_t<i, const variant<Types...>&>
+  get(const variant<Types...>& v)
+{
+  if(i != v.index())
+  {
+    detail::throw_bad_variant_access("i does not equal index()");
+  }
+
+  using type = typename std::decay<
+    detail::variant_element_t<i,variant<Types...>>
+  >::type;
+
+  auto visitor = detail::get_visitor<type>();
+  return *std::experimental::visit(visitor, v);
+}
+
+
+namespace detail
+{
+
+
+template<size_t i, class... Types>
+struct find_exactly_one_impl;
+
+template<size_t i, class T, class U, class... Types>
+struct find_exactly_one_impl<i,T,U,Types...> : find_exactly_one_impl<i+1,T,Types...> {};
+
+template<size_t i, class T, class... Types>
+struct find_exactly_one_impl<i,T,T,Types...> : std::integral_constant<size_t, i>
+{
+  static_assert(find_exactly_one_impl<i,T,Types...>::value == variant_not_found, "type can only occur once in type list");
+};
+
+
+template<size_t i, class T>
+struct find_exactly_one_impl<i,T> : std::integral_constant<size_t, variant_not_found> {};
+
+template<class T, class... Types>
+struct find_exactly_one : find_exactly_one_impl<0,T,Types...>
+{
+  static_assert(find_exactly_one::value != variant_not_found, "type not found in type list");
+};
+
+
+} // end detail
+
+
+template<class T, class... Types>
+__host__ __device__
+bool holds_alternative(const variant<Types...>& v)
+{
+  constexpr size_t i = detail::find_exactly_one<T,Types...>::value;
+  return i == v.index();
+}
+
+
+template<class T, class... Types>
+__host__ __device__
+typename std::remove_reference<T>::type&
+  get(variant<Types...>& v)
+{
+  return get<detail::find_type<T,Types...>::value>(v);
+}
+
+
+template<class T, class... Types>
+__host__ __device__
+const typename std::remove_reference<T>::type&
+  get(const variant<Types...>& v)
+{
+  return get<detail::find_type<T,Types...>::value>(v);
+}
+
+
+template<class T, class... Types>
+__host__ __device__
+typename std::remove_reference<T>::type&&
+  get(variant<Types...>&& v)
+{
+  return std::move(get<detail::find_type<T,Types...>::value>(v));
+}
+
+
+} // end experimental
+} // end std
+
+#ifdef VARIANT_UNDEF_HOST
+#  undef __host__
+#  undef VARIANT_UNDEF_HOST
+#endif
+
+#ifdef VARIANT_UNDEF_DEVICE
+#  undef __device__
+#  undef VARIANT_UNDEF_DEVICE
+#endif
+


### PR DESCRIPTION
As discussed on the previous call, this example program demonstrates how `always_ready_future<T>` may be used as an `inline_executor`'s associated future type.